### PR TITLE
design: pagination 아이콘 추가 및 컴포넌트 제작

### DIFF
--- a/src/components/common/Pagination/Pagination.stories.tsx
+++ b/src/components/common/Pagination/Pagination.stories.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from "react";
+import { Meta, StoryObj } from "@storybook/react";
+import Pagination, { PaginationProps } from "./Pagination";
+
+export default {
+  title: "Components/Pagination",
+  component: Pagination,
+} as Meta<typeof Pagination>;
+
+const Template = (args: PaginationProps) => {
+  const [currentPage, setCurrentPage] = useState(1);
+
+  return (
+    <Pagination
+      {...args}
+      currentPage={currentPage}
+      onPageChange={(page) => setCurrentPage(page)}
+    />
+  );
+};
+
+export const Default: StoryObj<typeof Pagination> = {
+  render: Template,
+  args: {
+    totalPages: 5,
+  },
+};

--- a/src/components/common/Pagination/Pagination.styles.ts
+++ b/src/components/common/Pagination/Pagination.styles.ts
@@ -1,0 +1,39 @@
+import styled from "styled-components";
+import PrevIcon from "../icon/PrevIcon/PrevIcon";
+import NextIcon from "../icon/NextIcon/NextIcon";
+
+export const PaginationContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 20px 0;
+`;
+
+export const ButtonWrapper = styled.div`
+  margin: 0 5px;
+`;
+
+export const PageButton = styled.button<{ active?: boolean }>`
+  background-color: ${({ active }) =>
+    active ? "var(--primary-color-org-light)" : "var(--color-white)"};
+  color: var(--font-color-light);
+  border: none;
+  border-radius: 50%;
+  padding: 5px 10px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+`;
+
+export const IconStyled = styled.div`
+  margin: 0 5px;
+  display: flex;
+  align-items: center;
+`;
+
+export const PrevIconComponent = PrevIcon;
+export const NextIconComponent = NextIcon;

--- a/src/components/common/Pagination/Pagination.tsx
+++ b/src/components/common/Pagination/Pagination.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import {
+  PaginationContainer,
+  PageButton,
+  ButtonWrapper,
+  IconStyled,
+  PrevIconComponent,
+  NextIconComponent,
+} from "./Pagination.styles";
+
+export interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  PrevIcon?: React.ElementType;
+  NextIcon?: React.ElementType;
+}
+
+const Pagination: React.FC<PaginationProps> = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+  PrevIcon = PrevIconComponent,
+  NextIcon = NextIconComponent,
+}) => {
+  const handlePageChange = (page: number) => {
+    if (page >= 1 && page <= totalPages) {
+      onPageChange(page);
+    }
+  };
+
+  return (
+    <PaginationContainer>
+      <ButtonWrapper>
+        <PageButton
+          onClick={() => handlePageChange(currentPage - 1)}
+          disabled={currentPage === 1}
+        >
+          <IconStyled as={PrevIcon} />
+        </PageButton>
+      </ButtonWrapper>
+      {Array.from({ length: totalPages }, (_, index) => (
+        <ButtonWrapper key={index + 1}>
+          <PageButton
+            active={index + 1 === currentPage}
+            onClick={() => handlePageChange(index + 1)}
+          >
+            {index + 1}
+          </PageButton>
+        </ButtonWrapper>
+      ))}
+      <ButtonWrapper>
+        <PageButton
+          onClick={() => handlePageChange(currentPage + 1)}
+          disabled={currentPage === totalPages}
+        >
+          <IconStyled as={NextIcon} />
+        </PageButton>
+      </ButtonWrapper>
+    </PaginationContainer>
+  );
+};
+
+export default Pagination;

--- a/src/components/common/icon/NextIcon/NextIcon.stories.ts
+++ b/src/components/common/icon/NextIcon/NextIcon.stories.ts
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import NextIcon from "./NextIcon";
+
+const meta = {
+  title: "Common/Icon/NextIcon",
+  component: NextIcon,
+} satisfies Meta<typeof NextIcon>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/common/icon/NextIcon/NextIcon.tsx
+++ b/src/components/common/icon/NextIcon/NextIcon.tsx
@@ -1,0 +1,7 @@
+import { GrFormNext } from "react-icons/gr";
+
+const NextIcon = () => {
+  return <GrFormNext />;
+};
+
+export default NextIcon;

--- a/src/components/common/icon/PrevIcon/PrevIcon.stories.ts
+++ b/src/components/common/icon/PrevIcon/PrevIcon.stories.ts
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import PrevIcon from "./PrevIcon";
+
+const meta = {
+  title: "Common/Icon/PrevIcon",
+  component: PrevIcon,
+} satisfies Meta<typeof PrevIcon>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/common/icon/PrevIcon/PrevIcon.tsx
+++ b/src/components/common/icon/PrevIcon/PrevIcon.tsx
@@ -1,0 +1,7 @@
+import { GrFormPrevious } from "react-icons/gr";
+
+const PrevIcon = () => {
+  return <GrFormPrevious />;
+};
+
+export default PrevIcon;


### PR DESCRIPTION
- [x] **pagination 아이콘 추가** 
: pagination에 필요한 아이콘들이 common/icon에 없어 react/io5 에서 찾아서 추가했습니다.

- [x] **pagination 구현**
 : next/ prev 정상 동작, 1페이지 이전 prev 버튼작동 X / 마지막 페이지 이후 next 버튼 작동 X 테스트 완료
(기본적인 동작은 테스트 해보았고, 이 외 필요한 부분을 수정하셔서 사용하면 될 것 같습니다 👍)